### PR TITLE
Node 0.5.x compat.

### DIFF
--- a/indexer.js
+++ b/indexer.js
@@ -3,8 +3,6 @@ var Fs = require('fs'),
     Url = require('url'),
     getMime = require('simple-mime')("application/octet-stream");
 
-var ENOENT = process.ENOENT || require('constants').ENOENT;
-
 module.exports = function setup(mount, root, showHidden) {
 
   return function handle(req, res, next) {
@@ -17,7 +15,7 @@ module.exports = function setup(mount, root, showHidden) {
     if (path[path.length - 1] === '/') { path = path.substr(0, path.length - 1); }
     Fs.stat(path, function (err, stat) {
       if (err) { 
-        if (err.errno === ENOENT) { return next(); }
+        if (err.code === 'ENOENT') { return next(); }
         return next(err); 
       }
       if (!stat.isDirectory()) {

--- a/share.js
+++ b/share.js
@@ -16,6 +16,7 @@ function listen() {
     Http.createServer(handler).listen(PORT);
     console.log("Serving %s at http://localhost:%s/", path, PORT);
   } catch (err) {
+    // this is probably broken in node 0.5.x. Should check err.code instead.
     if (err.errno !== 98) { throw err; }
     PORT++;
     listen();

--- a/static.js
+++ b/static.js
@@ -3,25 +3,6 @@ var Path = require('path'),
     Fs = require('fs'),
     getMime = require('simple-mime')("application/octet-stream");
 
-// Compat stuff to make this work on the v0.2.x and v0.3.x branches of node
-var StreamProto = require('net').Stream.prototype.__proto__;
-if (!StreamProto.hasOwnProperty('pipe')) {
-  var sys = require('sys');
-  StreamProto.pipe = function (other) {
-    sys.pump(this, other);
-  };
-}
-if (!process.EventEmitter.prototype.hasOwnProperty('once')) {
-  process.EventEmitter.prototype.once = function (type, listener) {
-    var self = this;
-    self.on(type, function g() {
-      self.removeListener(type, g);
-      listener.apply(this, arguments);
-    });
-   return this;
-  };
-}
-
 // Super simple static file server
 module.exports = function setup(mount, root, index) {
   return function (req, res, next) {

--- a/static.js
+++ b/static.js
@@ -4,7 +4,6 @@ var Path = require('path'),
     getMime = require('simple-mime')("application/octet-stream");
 
 // Compat stuff to make this work on the v0.2.x and v0.3.x branches of node
-var ENOENT = process.ENOENT || require('constants').ENOENT;
 var StreamProto = require('net').Stream.prototype.__proto__;
 if (!StreamProto.hasOwnProperty('pipe')) {
   var sys = require('sys');
@@ -38,7 +37,7 @@ module.exports = function setup(mount, root, index) {
     }
     function onStat(err, stat) {
       if (err) { 
-        if (err.errno === ENOENT) { return next(); }
+        if (err.code === 'ENOENT') { return next(); }
         return next(err);
       }
       if (index && stat.isDirectory()) {


### PR DESCRIPTION
Here's a quick fix for the newer nodes. `err.errno` has been removed, and `err.code` should be checked instead.

The second commit drops support for the older nodes, so you may not want that one, it's up to you.

Peace!
