### PR TITLE
restored wheat compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+require('fs').readdirSync(__dirname).forEach(function (name) {
+  if (name !== 'index.js' && name.substr(name.length-3) === ".js") {
+    var name = name.substr(0, name.length - 3);
+    Object.defineProperty(exports, name, {get: function () {
+      return require("./" + name);
+    }, enumerable: true});
+  }
+});
+

--- a/log.js
+++ b/log.js
@@ -1,0 +1,32 @@
+// A super simple logging middleware
+module.exports = function setup(special) {
+  special = special || {
+    "Content-Type": true,
+    "Location": true,
+    "Content-Length": true,
+    "Content-Range": true,
+  };
+  return function handle(req, res, next) {
+    var writeHead = res.writeHead;
+    var start = Date.now();
+    res.writeHead = function (code, headers) {
+      var extra = [];
+      if (headers) {
+        Object.keys(headers).forEach(function (key) {
+          if (special.hasOwnProperty(key)) {
+            extra.push(key + "=" + headers[key]);
+          }
+        });
+        if (!headers.hasOwnProperty('Date')) {
+          headers.Date = (new Date()).toUTCString();
+        }
+        headers.Server = "NodeJS " + process.version;
+        headers["X-Runtime"] = Date.now() - start;
+      }
+      console.log("%s %s %s %s", req.method, req.url, code, extra.join(" "));
+      res.writeHead = writeHead;
+      res.writeHead(code, headers);
+    };
+    next();
+  };
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "http://github.com/creationix/creationix.git"
   },
+  "main": "index.js",
   "bin": {
     "share": "./share.js"
   },


### PR DESCRIPTION
i was messing around with wheat today and both require('creationix') and Creationix.log() did not work using the latest version from the creationix repo. the npm package seems broken (no "main" entry in package.json)...? not sure in how far my fix goes against your cleanup from the last few days tho.
